### PR TITLE
QUIC

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -72,6 +72,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8aac770f1885fd7e387acedd76065302551364496e46b3dd00860b2f8359b9d"
 
 [[package]]
+name = "base64"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b41b7ea54a0c9d92199de89e20e58d49f02f8e699814ef3fdf266f6f748d15c7"
+
+[[package]]
 name = "bincode"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -102,10 +108,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "bumpalo"
+version = "3.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12ae9db68ad7fac5fe51304d20f016c911539251075a214f8e663babefa35187"
+
+[[package]]
 name = "byteorder"
 version = "1.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08c48aae112d48ed9f069b33538ea9e3e90aa263cfa3d1c24309612b1f7472de"
+
+[[package]]
+name = "bytes"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "130aac562c0dd69c56b3b1cc8ffd2e17be31d0b6c25b61c96b76231aa23e39e1"
+
+[[package]]
+name = "cc"
+version = "1.0.50"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95e28fa049fda1c330bcf9d723be7663a899c4679724b34c81e9f5a326aab8cd"
 
 [[package]]
 name = "cfg-if"
@@ -121,6 +145,17 @@ checksum = "ff41a3c2c1e39921b9003de14bf0439c7b63a9039637c291e1a64925d8ddfa45"
 dependencies = [
  "owning_ref",
  "parking_lot 0.4.8",
+]
+
+[[package]]
+name = "chrono"
+version = "0.4.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80094f509cf8b5ae86a4966a39b3ff66cd7e2a3e594accec3743ff3fabeab5b2"
+dependencies = [
+ "num-integer",
+ "num-traits",
+ "time",
 ]
 
 [[package]]
@@ -146,6 +181,22 @@ checksum = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
 dependencies = [
  "bitflags",
 ]
+
+[[package]]
+name = "core-foundation"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57d24c7a13c43e870e37c1556b74555437870a04514f7685f5b354e090567171"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3a71ab494c0b5b860bdc8407ae08978052417070c2ced38573a9157ad75b8ac"
 
 [[package]]
 name = "crossbeam-channel"
@@ -195,6 +246,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ct-logs"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d3686f5fa27dbc1d76c751300376e167c5a43387f44bb451fd1c24776e49113"
+dependencies = [
+ "sct",
+]
+
+[[package]]
 name = "env_logger"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -205,6 +265,20 @@ dependencies = [
  "log",
  "regex",
  "termcolor",
+]
+
+[[package]]
+name = "err-derive"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82f46c91bbed409ee74495549acbfcc7fae856e712e1df15afe75d0775eedc6c"
+dependencies = [
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn",
+ "synstructure",
 ]
 
 [[package]]
@@ -365,6 +439,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "js-sys"
+version = "0.3.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a27d435371a2fa5b6d2b028a74bbdb1234f308da363226a2854ca3ff8ba7055"
+dependencies = [
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "kernel32-sys"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -488,6 +571,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-integer"
+version = "0.1.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f6ea62e9d81a77cd3ee9a2a5b9b609447857f3d358704331e4ef39eb247fcba"
+dependencies = [
+ "autocfg",
+ "num-traits",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c62be47e61d1842b9170f0fdeec8eba98e60e90e5446449a0545e5152acd7096"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "num_cpus"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -502,6 +604,12 @@ name = "once_cell"
 version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1c601810575c99596d4afc46f78a678c80105117c379eb3650cf99b8a21ce5b"
+
+[[package]]
+name = "openssl-probe"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de"
 
 [[package]]
 name = "owning_ref"
@@ -567,6 +675,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "pem"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1581760c757a756a41f0ee3ff01256227bdf64cb752839779b95ffb01c59793"
+dependencies = [
+ "base64",
+ "lazy_static",
+ "regex",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -583,6 +702,32 @@ name = "ppv-lite86"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74490b50b9fbe561ac330df47c08f3f33073d2d00c150f719147d7c54522fa1b"
+
+[[package]]
+name = "proc-macro-error"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18f33027081eba0a6d8aba6d1b1c3a3be58cbb12106341c2d5759fcd9b5277e7"
+dependencies = [
+ "proc-macro-error-attr",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a5b4b77fdb63c1eca72173d68d24501c54ab1269409f6b672c85deb18af69de"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "syn-mid",
+ "version_check",
+]
 
 [[package]]
 name = "proc-macro-hack"
@@ -610,6 +755,42 @@ name = "quick-error"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
+
+[[package]]
+name = "quinn"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88de58d76d8f82fb28e5c89302119c102bb5b9ce57b034186b559b63ba147a0f"
+dependencies = [
+ "bytes",
+ "err-derive",
+ "futures",
+ "libc",
+ "mio",
+ "quinn-proto",
+ "rustls",
+ "tokio",
+ "tracing",
+ "webpki",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0ea0a358c179c6b7af34805c675d1664a9c6a234a7acd7efdbb32d2f39d3d2a"
+dependencies = [
+ "bytes",
+ "ct-logs",
+ "err-derive",
+ "rand 0.7.3",
+ "ring",
+ "rustls",
+ "rustls-native-certs",
+ "slab",
+ "tracing",
+ "webpki",
+]
 
 [[package]]
 name = "quote"
@@ -690,6 +871,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "rcgen"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d676dc4017e681ecedde29e5dfd54e0aaf19171174d2ffa9b8e6b4d293c0d2c5"
+dependencies = [
+ "chrono",
+ "pem",
+ "ring",
+ "yasna",
+]
+
+[[package]]
 name = "rdrand"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -723,10 +916,104 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fe5bd57d1d7414c6b5ed48563a2c855d995ff777729dcd91c369ec7fea395ae"
 
 [[package]]
+name = "ring"
+version = "0.16.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ba5a8ec64ee89a76c98c549af81ff14813df09c3e6dc4766c3856da48597a0c"
+dependencies = [
+ "cc",
+ "lazy_static",
+ "libc",
+ "spin",
+ "untrusted",
+ "web-sys",
+ "winapi 0.3.8",
+]
+
+[[package]]
+name = "rustls"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0d4a31f5d68413404705d6982529b0e11a9aacd4839d1d6222ee3b8cb4015e1"
+dependencies = [
+ "base64",
+ "log",
+ "ring",
+ "sct",
+ "webpki",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75ffeb84a6bd9d014713119542ce415db3a3e4748f0bfce1e1416cd224a23a5"
+dependencies = [
+ "openssl-probe",
+ "rustls",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
+name = "rustversion"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3bba175698996010c4f6dce5e7f173b6eb781fce25d2cfc45e27091ce0b79f6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "schannel"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "039c25b130bd8c1321ee2d7de7fde2659fa9c2744e4bb29711cfc852ea53cd19"
+dependencies = [
+ "lazy_static",
+ "winapi 0.3.8",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
+
+[[package]]
+name = "sct"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3042af939fca8c3453b7af0f1c66e533a15a86169e39de2657310ade8f98d3c"
+dependencies = [
+ "ring",
+ "untrusted",
+]
+
+[[package]]
+name = "security-framework"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "572dfa3a0785509e7a44b5b4bebcf94d41ba34e9ed9eb9df722545c3b3c4144a"
+dependencies = [
+ "bitflags",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ddb15a5fec93b7021b8a9e96009c5d8d51c15673569f7c0f6b7204e5b7b404f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "serde"
@@ -770,6 +1057,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c2fb2ec9bcd216a5b0d0ccf31ab17b5ed1d627960edff65bbe95d3ce221cefc"
 
 [[package]]
+name = "spin"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
+
+[[package]]
 name = "stable_deref_trait"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -793,6 +1086,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn-mid"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7be3539f6c128a931cf19dcee741c1af532c7fd387baa739c03dd2e96479338a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67656ea1dc1b41b1451851562ea232ec2e5a80242139f7e679ceccfb5d61f545"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "unicode-xid",
+]
+
+[[package]]
 name = "tcp-p2p-node-example"
 version = "0.1.0"
 dependencies = [
@@ -804,8 +1120,13 @@ dependencies = [
  "futures",
  "log",
  "p2p_node_stats",
+ "quinn",
  "rand 0.7.3",
+ "rcgen",
+ "rustls",
  "serde",
+ "tokio",
+ "webpki",
 ]
 
 [[package]]
@@ -836,6 +1157,73 @@ dependencies = [
 ]
 
 [[package]]
+name = "time"
+version = "0.1.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db8dcfca086c1143c9270ac42a2bbd8a7ee477b78ac8e45b19abfb0cbede4b6f"
+dependencies = [
+ "libc",
+ "redox_syscall",
+ "winapi 0.3.8",
+]
+
+[[package]]
+name = "tokio"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee5a0dd887e37d37390c13ff8ac830f992307fe30a1fff0ab8427af67211ba28"
+dependencies = [
+ "bytes",
+ "lazy_static",
+ "mio",
+ "num_cpus",
+ "pin-project-lite",
+ "slab",
+ "tokio-macros",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0c3acc6aa564495a0f2e1d59fab677cd7f81a19994cfc7f3ad0e64301560389"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tracing"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1721cc8cf7d770cc4257872507180f35a4797272f5962f24c806af9e7faf52ab"
+dependencies = [
+ "cfg-if",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fbad39da2f9af1cae3016339ad7f2c7a9e870f12e8fd04c4fd7ef35b30c0d2b"
+dependencies = [
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0aa83a9a47081cd522c09c81b31aec2c9273424976f922ad61c053b58350b715"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "unicode-width"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -848,16 +1236,102 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c"
 
 [[package]]
+name = "untrusted"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60369ef7a31de49bcb3f6ca728d4ba7300d9a1658f94c727d4cab8c8d9f4aece"
+
+[[package]]
 name = "vec_map"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05c78687fb1a80548ae3250346c3db86a80a7cdd77bda190189f2d0a0987c81a"
 
 [[package]]
+name = "version_check"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "078775d0255232fb988e6fccf26ddc9d1ac274299aaedcedce21c6f72cc533ce"
+
+[[package]]
 name = "wasi"
 version = "0.9.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.60"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2cc57ce05287f8376e998cbddfb4c8cb43b84a7ec55cf4551d7c00eef317a47f"
+dependencies = [
+ "cfg-if",
+ "wasm-bindgen-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-backend"
+version = "0.2.60"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d967d37bf6c16cca2973ca3af071d0a2523392e4a594548155d89a678f4237cd"
+dependencies = [
+ "bumpalo",
+ "lazy_static",
+ "log",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.60"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8bd151b63e1ea881bb742cd20e1d6127cef28399558f3b5d415289bc41eee3a4"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.60"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d68a5b36eef1be7868f668632863292e37739656a80fc4b9acec7b0bd35a4931"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-backend",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.60"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daf76fe7d25ac79748a37538b7daeed1c7a6867c92d3245c12c6222e4a20d639"
+
+[[package]]
+name = "web-sys"
+version = "0.3.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d6f51648d8c56c366144378a33290049eafdd784071077f6fe37dae64c1c4cb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki"
+version = "0.21.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1f50e1972865d6b1adb54167d1c8ed48606004c2c9d0ea5f1eeb34d95e863ef"
+dependencies = [
+ "ring",
+ "untrusted",
+]
 
 [[package]]
 name = "winapi"
@@ -910,4 +1384,13 @@ checksum = "d59cefebd0c892fa2dd6de581e937301d8552cb44489cdff035c6187cb63fa5e"
 dependencies = [
  "winapi 0.2.8",
  "winapi-build",
+]
+
+[[package]]
+name = "yasna"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a563d10ead87e2d798e357d44f40f495ad70bcee4d5c0d3f77a5b1b7376645d9"
+dependencies = [
+ "chrono",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,14 @@ p2p_node_stats = { git = "https://github.com/eadventurous/p2p-node-stats"}
 log = "0.4.0"
 env_logger = "0.7.1"
 
+# quinn deps
+rustls = { version = "0.17", features = ["quic", "dangerous_configuration"]}
+webpki = { version = "0.21"}
+rcgen = "0.8"
+quinn = {version = "0.6.1", features = ["rustls"] } # needs tokio context to function properly
+tokio = { version = "0.2", features = ["rt-core", "rt-threaded", "macros"] }
+
+
 [dependencies.serde]
 version = "1.0.105"
 features = ["derive"]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,3 @@
-use futures::executor::block_on;
 use std::{io, net::SocketAddr};
 extern crate clap;
 use crate::node::Node;
@@ -6,6 +5,7 @@ use clap::{value_t, App, Arg};
 
 pub mod helper_fns;
 pub mod node;
+pub mod quinn_ext;
 
 #[macro_use]
 extern crate log;
@@ -23,8 +23,10 @@ const NODE_TTL: f64 = 1000.0;
 //window size of requests to store and use for statistics
 pub const STATS_WINDOW_SIZE: usize = 100;
 
-async fn async_main() -> io::Result<()> {
+#[tokio::main]
+async fn main() -> io::Result<()> {
     env_logger::init();
+    //configure_client_untrusted();
     let matches = App::new("TCP p2p example node")
         .version("0.1")
         .author("Egor Ivkov e.o.ivkov@gmail.com")
@@ -95,8 +97,4 @@ async fn async_main() -> io::Result<()> {
         None => node.start().await?,
     }
     Ok(())
-}
-
-fn main() -> io::Result<()> {
-    block_on(async_main())
 }

--- a/src/node.rs
+++ b/src/node.rs
@@ -152,7 +152,7 @@ impl Node {
     }
 
     async fn listen_quic(&self) -> io::Result<()> {
-        let (mut incoming, server_cert) = quinn_ext::make_server_endpoint(self.listen_address)
+        let (mut incoming, _server_cert) = quinn_ext::make_server_endpoint(self.listen_address)
             .expect("Failed to initialize QUIC listener.");
 
         println!("QUIC: Listening on {}", self.listen_address);
@@ -165,8 +165,7 @@ impl Node {
             async {
                 // Each stream initiated by the client constitutes a new request.
                 while let Some(stream) = bi_streams.next().await {
-                    let (mut send, mut recv): (quinn::SendStream, quinn::RecvStream) = match stream
-                    {
+                    let (_send, mut recv): (quinn::SendStream, quinn::RecvStream) = match stream {
                         Err(quinn::ConnectionError::ApplicationClosed { .. }) => {
                             return Ok(());
                         }
@@ -230,7 +229,7 @@ impl Node {
         let quinn::NewConnection {
             connection: conn, ..
         } = { new_conn };
-        let (mut send, recv) = conn
+        let (mut send, _recv) = conn
             .open_bi()
             .await
             .expect("QUIC: Failed to open write stream.");

--- a/src/node.rs
+++ b/src/node.rs
@@ -1,4 +1,5 @@
 use crate::helper_fns::*;
+use crate::quinn_ext;
 use async_std::net::{TcpListener, TcpStream};
 use chashmap::CHashMap;
 use futures::{future::FutureExt, pin_mut, prelude::*, select};
@@ -48,6 +49,7 @@ pub struct Node {
     tx_bytes: usize,
     tx_interval_sec: usize,
     node_ttl: f64,
+    quic: bool,
 }
 
 impl Node {
@@ -66,6 +68,7 @@ impl Node {
             tx_bytes,
             tx_interval_sec,
             node_ttl,
+            quic: true,
         }
     }
 
@@ -134,8 +137,50 @@ impl Node {
             let mut stream = stream?;
             let mut buffer = [0u8; BUFFER_SIZE];
             let _read_size = stream.read(&mut buffer).await?;
-            self.handle_message(&buffer, &mut stream).await?;
+            self.handle_message(&buffer, stream.peer_addr()?).await?;
             stream.flush().await?;
+        }
+        Ok(())
+    }
+
+    async fn listen_quic(&self) -> io::Result<()> {
+        let (mut incoming, server_cert) = quinn_ext::make_server_endpoint(self.listen_address)
+            .expect("Failed to initialize QUIC listener.");
+
+        println!("Listening on {}", self.listen_address);
+        while let Some(conn_stream) = incoming.next().await {
+            let quinn::NewConnection {
+                connection,
+                mut bi_streams,
+                ..
+            } = conn_stream.await?;
+            async {
+                info!("established");
+                // Each stream initiated by the client constitutes a new request.
+                while let Some(stream) = bi_streams.next().await {
+                    let (mut send, mut recv): (quinn::SendStream, quinn::RecvStream) = match stream
+                    {
+                        Err(quinn::ConnectionError::ApplicationClosed { .. }) => {
+                            info!("connection closed");
+                            return Ok(());
+                        }
+                        Err(e) => {
+                            return Err(e);
+                        }
+                        Ok(s) => s,
+                    };
+                    let mut buffer = [0u8; BUFFER_SIZE];
+                    let _read_size = recv
+                        .read(&mut buffer)
+                        .await
+                        .expect("Failed reading the incoming message.");
+                    self.handle_message(&buffer, connection.remote_address())
+                        .await
+                        .expect("Failed handling the incoming message.");
+                }
+                Ok(())
+            }
+            .await?;
         }
         Ok(())
     }
@@ -188,7 +233,7 @@ impl Node {
         Ok(())
     }
 
-    async fn handle_message(&self, bytes: &[u8], stream: &mut TcpStream) -> io::Result<()> {
+    async fn handle_message(&self, bytes: &[u8], remote_address: SocketAddr) -> io::Result<()> {
         let message: Message =
             bincode::deserialize(bytes).expect("Failed to deserialize a message.");
         //info!("Got {:?}", message);
@@ -196,7 +241,7 @@ impl Node {
             Message::Ping(ping) => {
                 Node::send(
                     &Message::Pong(ping.clone()),
-                    addr_with_port(stream.peer_addr()?, ping.from_peer.listen_port),
+                    addr_with_port(remote_address, ping.from_peer.listen_port),
                 )
                 .await?;
             }
@@ -207,22 +252,21 @@ impl Node {
                         .get(&ping)
                         .expect("Failed to get sent ping entry.");
                     let peer_address =
-                        addr_with_port(stream.peer_addr()?, ping.to_peer.listen_port).to_string();
+                        addr_with_port(remote_address, ping.to_peer.listen_port).to_string();
                     let rtt = current_time() - sent_time.to_owned();
                     self.stats.add_ping(peer_address.clone(), rtt);
                     info!("Ping to {} returned in {:?}.", peer_address, rtt);
                 }
             }
             Message::Tx(tx) => {
-                let peer_address =
-                    addr_with_port(stream.peer_addr()?, tx.peer.listen_port).to_string();
+                let peer_address = addr_with_port(remote_address, tx.peer.listen_port).to_string();
                 let time = current_time() - tx.sent_time;
                 info!("Received tx from {} in {:?}", peer_address, time);
                 self.stats
                     .add_transmission(peer_address, time, tx.payload.len() as u32);
             }
             Message::NewPeer(peer) => {
-                let mut peer_address = stream.peer_addr()?;
+                let mut peer_address = remote_address;
                 peer_address.set_port(peer.listen_port);
                 info!(
                     "Received request to add new peer {} to swarm.",
@@ -250,7 +294,7 @@ impl Node {
                 info!("Added peer {}", address);
             }
             Message::RemovePeer(peer) => {
-                let peer_address = addr_with_port(stream.peer_addr()?, peer.listen_port);
+                let peer_address = addr_with_port(remote_address, peer.listen_port);
                 self.peers.remove(&peer_address);
                 info!("Removed peer {}", peer_address);
             }

--- a/src/quinn_ext.rs
+++ b/src/quinn_ext.rs
@@ -23,8 +23,17 @@ pub fn make_client_endpoint(
     Ok(endpoint)
 }
 
-pub fn make_client_endpoint_untrusted(bind_addr: SocketAddr) -> Result<Endpoint, Box<dyn Error>> {
-    unimplemented!()
+pub fn make_client_endpoint_untrusted() -> Result<Endpoint, Box<dyn Error>> {
+    let client_cfg = configure_client_untrusted();
+    let mut endpoint_builder = Endpoint::builder();
+    endpoint_builder.default_client_config(client_cfg);
+
+    let (endpoint, _) = endpoint_builder.bind(
+        &"[::]:0"
+            .parse()
+            .expect("Failed to parse client endpoint bind address"),
+    )?;
+    Ok(endpoint)
 }
 
 /// Dummy certificate verifier that treats any certificate as valid.

--- a/src/quinn_ext.rs
+++ b/src/quinn_ext.rs
@@ -1,0 +1,110 @@
+//! Commonly used code in most examples.
+
+use quinn::{
+    Certificate, CertificateChain, ClientConfig, ClientConfigBuilder, Endpoint, Incoming,
+    PrivateKey, ServerConfig, ServerConfigBuilder, TransportConfig,
+};
+use std::{error::Error, net::SocketAddr, sync::Arc};
+
+/// Constructs a QUIC endpoint configured for use a client only.
+///
+/// ## Args
+///
+/// - server_certs: list of trusted certificates.
+#[allow(unused)]
+pub fn make_client_endpoint(
+    bind_addr: SocketAddr,
+    server_certs: &[&[u8]],
+) -> Result<Endpoint, Box<dyn Error>> {
+    let client_cfg = configure_client(server_certs)?;
+    let mut endpoint_builder = Endpoint::builder();
+    endpoint_builder.default_client_config(client_cfg);
+    let (endpoint, _incoming) = endpoint_builder.bind(&bind_addr)?;
+    Ok(endpoint)
+}
+
+pub fn make_client_endpoint_untrusted(bind_addr: SocketAddr) -> Result<Endpoint, Box<dyn Error>> {
+    unimplemented!()
+}
+
+/// Dummy certificate verifier that treats any certificate as valid.
+/// NOTE, such verification is vulnerable to MITM attacks, but convenient for testing.
+struct SkipServerVerification;
+
+impl SkipServerVerification {
+    fn new() -> Arc<Self> {
+        Arc::new(Self)
+    }
+}
+
+impl rustls::ServerCertVerifier for SkipServerVerification {
+    fn verify_server_cert(
+        &self,
+        _roots: &rustls::RootCertStore,
+        _presented_certs: &[rustls::Certificate],
+        _dns_name: webpki::DNSNameRef,
+        _ocsp_response: &[u8],
+    ) -> Result<rustls::ServerCertVerified, rustls::TLSError> {
+        Ok(rustls::ServerCertVerified::assertion())
+    }
+}
+
+pub fn configure_client_untrusted() -> ClientConfig {
+    let mut cfg = ClientConfigBuilder::default().build();
+    let tls_cfg: &mut rustls::ClientConfig = Arc::get_mut(&mut cfg.crypto).unwrap();
+    // this is only available when compiled with "dangerous_configuration" feature
+    tls_cfg
+        .dangerous()
+        .set_certificate_verifier(SkipServerVerification::new());
+    cfg
+}
+
+/// Constructs a QUIC endpoint configured to listen for incoming connections on a certain address
+/// and port.
+///
+/// ## Returns
+///
+/// - a sream of incoming QUIC connections
+/// - server certificate serialized into DER format
+#[allow(unused)]
+pub fn make_server_endpoint(bind_addr: SocketAddr) -> Result<(Incoming, Vec<u8>), Box<dyn Error>> {
+    let (server_config, server_cert) = configure_server()?;
+    let mut endpoint_builder = Endpoint::builder();
+    endpoint_builder.listen(server_config);
+    let (_endpoint, incoming) = endpoint_builder.bind(&bind_addr)?;
+    Ok((incoming, server_cert))
+}
+
+/// Builds default quinn client config and trusts given certificates.
+///
+/// ## Args
+///
+/// - server_certs: a list of trusted certificates in DER format.
+fn configure_client(server_certs: &[&[u8]]) -> Result<ClientConfig, Box<dyn Error>> {
+    let mut cfg_builder = ClientConfigBuilder::default();
+    for cert in server_certs {
+        cfg_builder.add_certificate_authority(Certificate::from_der(&cert)?)?;
+    }
+    Ok(cfg_builder.build())
+}
+
+/// Returns default server configuration along with its certificate.
+fn configure_server() -> Result<(ServerConfig, Vec<u8>), Box<dyn Error>> {
+    let cert = rcgen::generate_simple_self_signed(vec!["localhost".into()]).unwrap();
+    let cert_der = cert.serialize_der().unwrap();
+    let priv_key = cert.serialize_private_key_der();
+    let priv_key = PrivateKey::from_der(&priv_key)?;
+
+    let mut transport_config = TransportConfig::default();
+    transport_config.stream_window_uni(0);
+    let mut server_config = ServerConfig::default();
+    server_config.transport = Arc::new(transport_config);
+    let mut cfg_builder = ServerConfigBuilder::new(server_config);
+    let cert = Certificate::from_der(&cert_der)?;
+    cfg_builder.certificate(CertificateChain::from_certs(vec![cert]), priv_key)?;
+
+    Ok((cfg_builder.build(), cert_der))
+}
+
+#[allow(unused)]
+pub const ALPN_QUIC_HTTP: &[&[u8]] = &[b"hq-27"];


### PR DESCRIPTION
Add support of QUIC transport protocol through [quinn](https://github.com/djc/quinn). Start with `cargo run -- -t=quic` to select this protocol.